### PR TITLE
Treat hyphens as word parts for motion, completion

### DIFF
--- a/rc/raku.kak
+++ b/rc/raku.kak
@@ -12,6 +12,7 @@ hook global WinSetOption filetype=raku %{
     require-module raku
 
     set-option window static_words %opt{raku_static_words}
+    set-option buffer extra_word_chars '_' '-'
 
     hook window ModeChange pop:insert:.* -group raku-trim-indent %{ try %{ execute-keys -draft <a-x>s^\h+$<ret>d } }
 


### PR DESCRIPTION
In Raku variables and sub/method names use "kebab case". For example

    my $user-id = 123;
    my $success = verify-admin($user-id);

Adding '-' to the `extra_word_chars` option list (which is only `_` by default) would let `user-id` or `verify-admin` appear in the code completion list, and allow selecting them whole with a motion like "w".

There might be something more sophisticated we can do here, but this feels like an improvement on the status quo.